### PR TITLE
Decouple notification interfaces from web push receiver type

### DIFF
--- a/src/main/Notifications/IPushNotificationService.cs
+++ b/src/main/Notifications/IPushNotificationService.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace ei8.Net.Http.Notifications
-{
-    public interface IPushNotificationService
-    {
-        Task SendAsync(PushNotificationPayload payload, WebPushReceiver subscription);
-    }
-}

--- a/src/main/Notifications/Interface/INotificationPayload.cs
+++ b/src/main/Notifications/Interface/INotificationPayload.cs
@@ -1,0 +1,7 @@
+﻿namespace ei8.Net.Http.Notifications.Interface
+{
+    public interface INotificationPayload
+    {
+        string Body { get; set; }
+    }
+}

--- a/src/main/Notifications/Interface/INotificationReceiver.cs
+++ b/src/main/Notifications/Interface/INotificationReceiver.cs
@@ -1,0 +1,6 @@
+﻿namespace ei8.Net.Http.Notifications.Interface
+{
+    public interface INotificationReceiver
+    {
+    }
+}

--- a/src/main/Notifications/Interface/IPushNotificationService.cs
+++ b/src/main/Notifications/Interface/IPushNotificationService.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace ei8.Net.Http.Notifications.Interface
+{
+    public interface IPushNotificationService<in T, in U> 
+        where T: INotificationPayload 
+        where U : INotificationReceiver
+    {
+        Task SendAsync(T payload, U subscription);
+    }
+}

--- a/src/main/Notifications/WebPushNotificationPayload.cs
+++ b/src/main/Notifications/WebPushNotificationPayload.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using ei8.Net.Http.Notifications.Interface;
+using System;
 using System.Collections.Generic;
 
 namespace ei8.Net.Http.Notifications
 {
-    public class PushNotificationPayload
+    public class WebPushNotificationPayload : INotificationPayload
     {
         public string Title { get; set; }
 

--- a/src/main/Notifications/WebPushNotificationService.cs
+++ b/src/main/Notifications/WebPushNotificationService.cs
@@ -1,19 +1,20 @@
-﻿using System.Text.Json;
+﻿using ei8.Net.Http.Notifications.Interface;
+using System.Text.Json;
 using System.Threading.Tasks;
 using WebPush;
 
 namespace ei8.Net.Http.Notifications
 {
-    public class PushNotificationService : IPushNotificationService
+    public class WebPushNotificationService : IPushNotificationService<WebPushNotificationPayload, WebPushReceiver>
     {
         private readonly VapidDetails vapidDetails;
 
-        public PushNotificationService(PushNotificationSettings settings)
+        public WebPushNotificationService(PushNotificationSettings settings)
         {
             this.vapidDetails = new VapidDetails(settings.PushOwner, settings.PushPublicKey, settings.PushPrivateKey);
         }
 
-        public async Task SendAsync(PushNotificationPayload payload, WebPushReceiver subscription)
+        public async Task SendAsync(WebPushNotificationPayload payload, WebPushReceiver subscription)
         {
             var pushSubscription = new PushSubscription(subscription.Endpoint, subscription.P256DH, subscription.Auth);
             var jsonPayload = JsonSerializer.Serialize(payload, Constants.CamelCaseSerialization);

--- a/src/main/Notifications/WebPushReceiver.cs
+++ b/src/main/Notifications/WebPushReceiver.cs
@@ -1,6 +1,8 @@
-﻿namespace ei8.Net.Http.Notifications
+﻿using ei8.Net.Http.Notifications.Interface;
+
+namespace ei8.Net.Http.Notifications
 {
-    public class WebPushReceiver
+    public class WebPushReceiver : INotificationReceiver
     {
         public string Endpoint { get; set; }
         public string P256DH { get; set; }

--- a/src/main/ServiceCollectionExtensions.cs
+++ b/src/main/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using ei8.Net.Http.Notifications;
+using ei8.Net.Http.Notifications.Interface;
+using ei8.Net.Http.PayloadHashing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ei8.Net.Http
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddEi8Http(this IServiceCollection services)
+        {
+            services.AddScoped<IPushNotificationService<WebPushNotificationPayload, WebPushReceiver>, WebPushNotificationService>();
+            services.AddScoped<IPayloadHashService, HttpPayloadHashService>();
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
* Make interfaces generic and not coupled to a single type of push notification
* Add `ServiceCollection` extensions for injecting the package classes with .NET Core with a single call